### PR TITLE
Fix for fullscreen on Mac issue931

### DIFF
--- a/src/browsermainwindow.cpp
+++ b/src/browsermainwindow.cpp
@@ -1379,6 +1379,7 @@ void BrowserMainWindow::zoomOut()
 void BrowserMainWindow::viewFullScreen(bool makeFullScreen)
 {
     if (makeFullScreen) {
+        setUnifiedTitleAndToolBarOnMac(false);
         setWindowState(windowState() | Qt::WindowFullScreen);
 
         menuBar()->hide();
@@ -1386,6 +1387,7 @@ void BrowserMainWindow::viewFullScreen(bool makeFullScreen)
     } else {
         setWindowState(windowState() & ~Qt::WindowFullScreen);
 
+        setUnifiedTitleAndToolBarOnMac(true);
         menuBar()->setVisible(m_menuBarVisible);
         statusBar()->setVisible(m_statusBarVisible);
     }


### PR DESCRIPTION
As discussed here:

http://code.google.com/p/arora/issues/detail?id=931

Arora would crash when coming out of fullscreen mode. I had a look and managed to fix it but I don't know if it's the best way (just started with Qt).

I would like to collaborate more, I've seen that the Issue list is not very active. I'd be happy to start by doing some small tasks to get familiar with the code and the way you guys work (and git).
