### PR TITLE
Select current language in language-chooser

### DIFF
--- a/src/utils/languagemanager.cpp
+++ b/src/utils/languagemanager.cpp
@@ -246,7 +246,7 @@ void LanguageManager::chooseNewLanguage()
 
     QStringList items;
     int defaultItem = -1;
-    QString current = currentLanguage();
+    QString current = convertStringToLanguageFile(currentLanguage());
     foreach (const QString &name, m_languages) {
         QLocale locale(name);
         QString string = QString(QLatin1String("%1, %2 (%3) %4"))


### PR DESCRIPTION
In the event that we're using a 'fallback' language, pre-select the actual currently-used language, rather than always dropping through to en_US
